### PR TITLE
Further fix `oplus.fstab` support

### DIFF
--- a/native/jni/init/init.hpp
+++ b/native/jni/init/init.hpp
@@ -26,6 +26,8 @@ struct fstab_entry {
     fstab_entry() = default;
     fstab_entry(const fstab_entry &) = delete;
     fstab_entry(fstab_entry &&) = default;
+    fstab_entry &operator=(const fstab_entry&) = delete;
+    fstab_entry &operator=(fstab_entry&&) = default;
     void to_file(FILE *fp);
 };
 


### PR DESCRIPTION
In some oneplus devices, `oplus.fstab` does exists but `init` never
loaded it and those entries in `oplus.fstab` are written directly to
`fstab.qcom`. Previous implementation will introduce duplicate entries
to `fstab.qcom` and brick the device. This commit filters those entries
from `oplus.fstab` that are already in `fstab.qcom` and further filters
duplicated entries in `oplus.fstab` (keep only the last entry).

Fix #5016